### PR TITLE
ci: Add ios and android builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,98 @@
+name: Build
+on:
+  push:
+    branches:
+      - '**'
+      - '!dev'
+
+jobs:
+  build-ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Cache node_modules
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Build iOS app
+        id: buildiOS
+        run: node apps/mobile-wallet/scripts/buildIos.js && echo "buildPath=$(xargs < iosBuildPath)" >> $GITHUB_OUTPUT
+
+      - name: Upload iOS build to GitHub Actions Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: mobilewallet.app
+          path: ${{steps.buildiOS.outputs.buildPath}}
+          if-no-files-found: error
+  
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Set up JDK 17 for x64
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          architecture: x64
+
+      # Cache node_modules
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Build Android apk
+        id: buildAndroid
+        run: node apps/mobile-wallet/scripts/buildAndroid.js
+
+      - name: Upload Android apk to GitHub Actions Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-release.apk
+          path: apps/mobile-wallet/android/app/build/outputs/apk/release/app-release.apk
+          if-no-files-found: error
+
+  bundle-ios:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Cache node_modules
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Bundle javascript for iOS
+        run: cd ./apps/mobile-wallet && npx expo export --platform ios
+
+  bundle-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Cache node_modules
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Bundle javascript for Android
+        run: cd ./apps/mobile-wallet && npx expo export --platform android

--- a/apps/mobile-wallet/scripts/buildAndroid.js
+++ b/apps/mobile-wallet/scripts/buildAndroid.js
@@ -1,0 +1,52 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+// Expo cli is built well for running the app builds on EAS but it is pretty hard to do it otherwise on other CI-s
+// Thus, we reuse some parts of the `expo run:android` that are only responsible for building the application.
+// This file only uses a part of packages/@expo/cli/src/run/android/runAndroidAsync.ts code
+// This should be revised if we decide to update the Expo package
+const { assembleAsync } = require('@expo/cli/build/src/start/platforms/android/gradle');
+const { ensureNativeProjectAsync } = require('@expo/cli/build/src/run/ensureNativeProject');
+
+const { resolveGradleProps } = require('@expo/cli/build/src/run/android//resolveGradleProps');
+const { resolveLaunchPropsAsync } = require('@expo/cli/build/src/run/android/resolveLaunchProps');
+const { resolveBundlerPropsAsync } = require('@expo/cli/build/src/run/resolveBundlerProps');
+
+const path = require('path');
+
+async function resolveOptionsAsync(projectRoot, options) {
+  return {
+    ...(await resolveBundlerPropsAsync(projectRoot, options)),
+    ...resolveGradleProps(projectRoot, options),
+    ...(await resolveLaunchPropsAsync(projectRoot)),
+    variant: options.variant ?? 'debug',
+    // We should not resolve to a device as we only want an apk
+    device: undefined,
+    buildCache: !!options.buildCache,
+    install: !!options.install,
+  };
+}
+
+async function buildAndroid(projectRoot, options) {
+  await ensureNativeProjectAsync(projectRoot, { platform: 'android', install: options.install });
+
+  const props = await resolveOptionsAsync(projectRoot, options);
+
+  const androidProjectRoot = path.join(projectRoot, 'android');
+
+  await assembleAsync(androidProjectRoot, {
+    variant: props.variant,
+    port: props.port,
+    appName: props.appName,
+    buildCache: props.buildCache,
+  });
+}
+
+buildAndroid(path.resolve(__dirname, '..'), {
+  buildCache: true,
+  bundler: true,
+  install: true,
+  port: undefined,
+  variant: 'release',
+  device: undefined,
+});

--- a/apps/mobile-wallet/scripts/buildIos.js
+++ b/apps/mobile-wallet/scripts/buildIos.js
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+// Expo cli is built well for running the app builds on EAS but it is pretty hard to do it otherwise on other CI-s
+// Thus, we reuse some parts of the `expo run:ios` that are only responsible for building the application.
+// This file only uses a part of packages/@expo/cli/src/run/ios/runIosAsync.ts code
+// This should be revised if we decide to update the Expo package
+const { ensureNativeProjectAsync } = require('@expo/cli/build/src/run/ensureNativeProject');
+const { maybePromptToSyncPodsAsync } = require('@expo/cli/build/src/utils/cocoapods');
+const { resolveOptionsAsync } = require('@expo/cli/build/src/run/ios/options/resolveOptions');
+const { profile } = require('@expo/cli/build/src/utils/profile');
+const XcodeBuild = require('@expo/cli/build/src/run/ios/XcodeBuild');
+const path = require('path');
+const fs = require('fs');
+
+async function buildIos(projectRoot, options) {
+  if (await ensureNativeProjectAsync(projectRoot, { platform: 'ios', install: true })) {
+    await maybePromptToSyncPodsAsync(projectRoot);
+  }
+
+  // Resolve the CLI arguments into useable options.
+  const props = await resolveOptionsAsync(projectRoot, options);
+
+  // Spawn the `xcodebuild` process to create the app binary.
+  const buildOutput = await XcodeBuild.buildAsync(props);
+
+  // Find the path to the built app binary, this will be used to install the binary
+  // on a device.
+  const binaryPath = await profile(XcodeBuild.getAppBinaryPath)(buildOutput);
+
+  fs.writeFile('./iosBuildPath', binaryPath, () => {});
+}
+
+buildIos(path.resolve(__dirname, '..'), {
+  buildCache: true,
+  install: true,
+  bundler: false,
+  port: undefined,
+  device: undefined,
+  scheme: undefined,
+  configuration: 'Release',
+});


### PR DESCRIPTION
Run iOS and Android builds on Github Actions.

Expo tooling is built pretty well to support EAS cloud builds, but not so well for running builds on other types of CI. Thus, i am reusing parts of `expo run:android` and `expo run:ios` scripts that are only responsible for building a release application, without running the dev server or opening the simulator/emulator.

iOS .app and Android .apk files are going to be uploaded to Github Actions as artefacts. Both are drag-and-droppable to their respective simulator / emulator:


https://github.com/leather-wallet/mono/assets/22010816/148e4f24-5992-4480-8b77-467d8d9fc198


