### PR TITLE
chore: migrate colours to ink and remove superflous colours, closes #41

### DIFF
--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leather-wallet/tokens",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Shared design tokens",
   "main": "src/index.ts",
   "homepage": "https://github.com/leather-wallet/mono/tree/dev/packages/tokens",

--- a/packages/tokens/src/colors.ts
+++ b/packages/tokens/src/colors.ts
@@ -50,7 +50,7 @@ export const colors = {
     500: { value: '#165C38' },
     600: { value: '#00753A' },
   },
-  lightModeBrown: {
+  lightModeInk: {
     1: { value: '#FFFFFF' },
     2: { value: '#F7F5F3' },
     3: { value: '#F5F1ED' },
@@ -64,7 +64,7 @@ export const colors = {
     11: { value: '#4A423B' },
     12: { value: '#12100F' },
   },
-  darkModeBrown: {
+  darkModeInk: {
     1: { value: '#12100F' },
     2: { value: '#2C2A24' },
     3: { value: '#4A423B' },
@@ -78,35 +78,11 @@ export const colors = {
     11: { value: '#DED6CD' },
     12: { value: '#F5F1ED' },
   },
-  lightModeInk: {
-    1: { value: '#FFFFFF' },
-    2: { value: '#F9F9F9' },
-    3: { value: '#F1F1F1' },
-    4: { value: '#EBEBEB' },
-    5: { value: '#E4E4E4' },
-    6: { value: '#DDDDDD' },
-    7: { value: '#D4D4D4' },
-    8: { value: '#BBBBBB' },
-    9: { value: '#8D8D8D' },
-    10: { value: '#808080' },
-    11: { value: '#646464' },
-    12: { value: '#12100F' },
-  },
-  darkModeInk: {
-    1: { value: '#12100F' },
-    2: { value: '#1B1B1B' },
-    3: { value: '#282828' },
-    4: { value: '#303030' },
-    5: { value: '#373737' },
-    6: { value: '#3F3F3F' },
-    7: { value: '#4A4A4A' },
-    8: { value: '#606060' },
-    9: { value: '#6E6E6E' },
-    10: { value: '#818181' },
-    11: { value: '#B1B1B1' },
-    12: { value: '#EEEEEE' },
-  },
+
   lightModeStacks: { value: '#5546FF' },
   darkModeStacks: { value: '#7F80FF' },
   overlay: { value: 'rgba(0,0,0,0.4)' },
+  transparentInk: {
+    2: { value: 'rgba(148, 134, 119, 0.1)' },
+  },
 } as const;

--- a/packages/tokens/src/semantic-tokens.ts
+++ b/packages/tokens/src/semantic-tokens.ts
@@ -1,20 +1,6 @@
 export const semanticTokens = {
   colors: {
-    // Primative colours defined as semantic tokens to match Radix
-    brown: {
-      1: { value: { base: '{colors.lightModeBrown.1}', _dark: '{colors.darkModeBrown.1}' } },
-      2: { value: { base: '{colors.lightModeBrown.2}', _dark: '{colors.darkModeBrown.2}' } },
-      3: { value: { base: '{colors.lightModeBrown.3}', _dark: '{colors.darkModeBrown.3}' } },
-      4: { value: { base: '{colors.lightModeBrown.4}', _dark: '{colors.darkModeBrown.4}' } },
-      5: { value: { base: '{colors.lightModeBrown.5}', _dark: '{colors.darkModeBrown.5}' } },
-      6: { value: { base: '{colors.lightModeBrown.6}', _dark: '{colors.darkModeBrown.6}' } },
-      7: { value: { base: '{colors.lightModeBrown.7}', _dark: '{colors.darkModeBrown.7}' } },
-      8: { value: { base: '{colors.lightModeBrown.8}', _dark: '{colors.darkModeBrown.8}' } },
-      9: { value: { base: '{colors.lightModeBrown.9}', _dark: '{colors.darkModeBrown.9}' } },
-      10: { value: { base: '{colors.lightModeBrown.10}', _dark: '{colors.darkModeBrown.10}' } },
-      11: { value: { base: '{colors.lightModeBrown.11}', _dark: '{colors.darkModeBrown.11}' } },
-      12: { value: { base: '{colors.lightModeBrown.12}', _dark: '{colors.darkModeBrown.12}' } },
-    },
+    // Primitive colours defined as semantic tokens to match Radix
     ink: {
       1: { value: { base: '{colors.lightModeInk.1}', _dark: '{colors.darkModeInk.1}' } },
       2: { value: { base: '{colors.lightModeInk.2}', _dark: '{colors.darkModeInk.2}' } },
@@ -31,43 +17,43 @@ export const semanticTokens = {
     },
     accent: {
       'text-primary': {
-        value: { base: '{colors.lightModeBrown.12}', _dark: '{colors.darkModeBrown.12}' },
+        value: { base: '{colors.lightModeInk.12}', _dark: '{colors.darkModeInk.12}' },
       },
       'text-subdued': {
-        value: { base: '{colors.lightModeBrown.9}', _dark: '{colors.darkModeBrown.11}' },
+        value: { base: '{colors.lightModeInk.9}', _dark: '{colors.darkModeInk.11}' },
       },
       'action-primary-hover': {
-        value: { base: '{colors.lightModeBrown.11}', _dark: '{colors.darkModeBrown.10}' },
+        value: { base: '{colors.lightModeInk.11}', _dark: '{colors.darkModeInk.10}' },
       },
       'action-primary-default': {
-        value: { base: '{colors.lightModeBrown.12}', _dark: '{colors.darkModeBrown.9}' },
+        value: { base: '{colors.lightModeInk.12}', _dark: '{colors.darkModeInk.9}' },
       },
       'border-hover': {
-        value: { base: '{colors.lightModeBrown.5}', _dark: '{colors.darkModeBrown.8}' },
+        value: { base: '{colors.lightModeInk.5}', _dark: '{colors.darkModeInk.8}' },
       },
       'border-default': {
-        value: { base: '{colors.lightModeBrown.4}', _dark: '{colors.darkModeBrown.7}' },
+        value: { base: '{colors.lightModeInk.4}', _dark: '{colors.darkModeInk.7}' },
       },
       'non-interactive': {
-        value: { base: '{colors.lightModeBrown.7}', _dark: '{colors.darkModeBrown.6}' },
+        value: { base: '{colors.lightModeInk.7}', _dark: '{colors.darkModeInk.6}' },
       },
       'component-background-pressed': {
-        value: { base: '{colors.lightModeBrown.4}', _dark: '{colors.darkModeBrown.5}' },
+        value: { base: '{colors.lightModeInk.4}', _dark: '{colors.darkModeInk.5}' },
       },
       'component-background-hover': {
-        value: { base: 'rgba(148, 134, 119, 0.1)', _dark: 'rgba(148, 134, 119, 0.1)' },
+        value: { base: '{colors.transparentInk.2}', _dark: 'colors.transparentInk.2' },
       },
       'component-background-default': {
-        value: { base: '{colors.lightModeBrown.3}', _dark: '{colors.darkModeBrown.3}' },
+        value: { base: '{colors.lightModeInk.3}', _dark: '{colors.darkModeInk.3}' },
       },
       'background-secondary': {
-        value: { base: '{colors.lightModeBrown.3}', _dark: '{colors.darkModeBrown.2}' },
+        value: { base: '{colors.lightModeInk.3}', _dark: '{colors.darkModeInk.2}' },
       },
       'background-primary': {
-        value: { base: '{colors.lightModeBrown.1}', _dark: '{colors.darkModeBrown.1}' },
+        value: { base: '{colors.lightModeInk.1}', _dark: '{colors.darkModeInk.1}' },
       },
       'notification-text': {
-        value: { base: '{colors.lightModeBrown.12}', _dark: '{colors.darkModeBrown.12}' },
+        value: { base: '{colors.lightModeInk.12}', _dark: '{colors.darkModeInk.12}' },
       },
     },
     disabled: {
@@ -82,7 +68,7 @@ export const semanticTokens = {
       },
     },
     invert: {
-      value: { base: '{colors.darkModeBrown.1}', _dark: '{colors.lightModeBrown.1}' },
+      value: { base: '{colors.darkModeInk.1}', _dark: '{colors.lightModeInk.1}' },
     },
     stacks: {
       value: { base: '{colors.lightModeStacks}', _dark: '{colors.darkModeStacks}' },


### PR DESCRIPTION
This PR:
- deprecates `brown` colours, renaming as `ink` 
- adds a new transparent colour `transparentInk`

Relates to https://github.com/leather-wallet/extension/issues/4805
