### PR TITLE
chore: add focus to monorepo and increment package

### DIFF
--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leather-wallet/tokens",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Shared design tokens",
   "main": "src/index.ts",
   "homepage": "https://github.com/leather-wallet/mono/tree/dev/packages/tokens",

--- a/packages/tokens/src/semantic-tokens.ts
+++ b/packages/tokens/src/semantic-tokens.ts
@@ -67,6 +67,9 @@ export const semanticTokens = {
         value: { base: '{colors.lightModeRed.600}', _dark: '{colors.darkModeRed.600}' },
       },
     },
+    focus: {
+      value: { base: '{colors.lightModeBlue.500}', _dark: '{colors.darkModeBlue.500}' },
+    },
     invert: {
       value: { base: '{colors.darkModeInk.1}', _dark: '{colors.lightModeInk.1}' },
     },


### PR DESCRIPTION
This PR:
- adds the `focus` colour I found a `TODO` for from extension PR #4820
- increments the package number to release https://github.com/leather-wallet/mono/pull/49