### PR TITLE
fix: primary action hover in dark mode

### DIFF
--- a/packages/tokens/src/colors.ts
+++ b/packages/tokens/src/colors.ts
@@ -97,7 +97,7 @@ export const colorThemes = {
   dark: {
     'ink.text-primary': '#F5F1ED',
     'ink.text-subdued': '#CFC8BB',
-    'ink.action-primary-hover': '#716A604D',
+    'ink.action-primary-hover': '#CFC8BB',
     'ink.action-primary-default': '#F5F1ED',
     'ink.border-transparent': '#F5F1ED33',
     'ink.border-default': '#554D44',


### PR DESCRIPTION
Use non-transparent colour for action-primary-hover in dark mode to fix broken hover states