### PR TITLE
chore: update token package version

### DIFF
--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leather-wallet/tokens",
   "description": "Shared design tokens",
-  "version": "0.0.11",
+  "version": "0.0.14",
   "author": "Leather.io contact@leather.io",
   "scripts": {
     "typecheck": "tsc --noEmit -p ./tsconfig.json"


### PR DESCRIPTION
Yesterday, I incremented the `token` package version to `11` based on the previous version.

I then did a release `@leather-wallet/tokens@0.0.11` and published the new version. 

After doing that and going to NPM I see we already release version `0.0.13` 2 weeks ago and my latest release was still labelled as `0.0.13`. 

![Screenshot 2024-03-22 at 06 15 54](https://github.com/leather-wallet/mono/assets/2938440/b72aec40-c68e-48d0-b3cc-c8c7597ed7e9)

Creating this manual request now but we need a better way so that the `package.json` version is auto updated in each package OR PR's are blocked without an updated package version