### PR TITLE
fix: smaller code font-size style

### DIFF
--- a/packages/tokens/src/typography.ts
+++ b/packages/tokens/src/typography.ts
@@ -127,8 +127,8 @@ function getTextVariants({ platform }: { platform: Platform }) {
 
   const code = {
     ...commonFiracodeStyles,
-    fontSize: transformSize(15),
-    lineHeight: transformSize(20),
+    fontSize: transformSize(13),
+    lineHeight: transformSize(18),
     fontWeight: transformWeight(450),
   };
 


### PR DESCRIPTION
Code text font-size was too large, this is a sync up with the change in the design system