### PR TITLE
fix: add missing 'hex' field in signPsbt response

### DIFF
--- a/packages/types/src/methods/sign-psbt.ts
+++ b/packages/types/src/methods/sign-psbt.ts
@@ -25,7 +25,8 @@ export interface SignPsbtRequestParams {
 }
 
 export interface SignPsbtResponseBody {
-  txid: string;
+  txid?: string;
+  hex: string;
 }
 
 export type SignPsbtRequest = RpcRequest<'signPsbt', SignPsbtRequestParams>;


### PR DESCRIPTION
The hex field was missing from the response and requires a hack to get the typings correct.

Also, I'm pretty sure the txid field is only returned if broadcast is set to true, so made it nullable.