### PR TITLE
fix: types success bug

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,6 +4,7 @@ import { DefineSendTransferMethod } from './methods/send-transfer';
 import { DefineSignMessageMethod } from './methods/sign-message';
 import { DefineSignPsbtMethod } from './methods/sign-psbt';
 import { DefineStxSignMessageMethod } from './methods/stx-sign-message';
+import { ExtractSuccessResponse } from './rpc';
 import { ValueOf } from './utils';
 
 export * from './rpc';
@@ -27,7 +28,11 @@ export type RpcResponses = ValueOf<MethodMap>['response'];
 export type MethodNames = keyof MethodMap;
 
 export interface RequestFn {
-  <T extends MethodNames>(arg: T, params?: object | string[]): Promise<MethodMap[T]['response']>;
+  <T extends MethodNames>(
+    arg: T,
+    params?: object | string[]
+    // `Promise` throws if unsucessful, so here we extract the successful response
+  ): Promise<ExtractSuccessResponse<MethodMap[T]['response']>>;
 }
 
 export interface ListenFn {

--- a/packages/types/src/methods/get-addresses.ts
+++ b/packages/types/src/methods/get-addresses.ts
@@ -12,10 +12,6 @@ export interface AddressResponseBody extends AllowAdditionalProperties {
   addresses: BtcAddress[];
 }
 
-export interface Params extends AllowAdditionalProperties {
-  types: PaymentTypes[];
-}
-
 export type GetAddressesRequest = RpcRequest<'getAddresses'>;
 
 export type GetAddressesResponse = RpcResponse<AddressResponseBody>;


### PR DESCRIPTION
Closes leather-wallet/extension#5314

Promise would return error or success value, yet we only resolve the promise when it's successful.