### PR TITLE
fix: stacks contract id on asset info

### DIFF
--- a/packages/models/src/crypto-assets/crypto-asset-info.model.ts
+++ b/packages/models/src/crypto-assets/crypto-asset-info.model.ts
@@ -49,7 +49,7 @@ export interface Src20CryptoAssetInfo extends CryptoAssetInfo {
 
 // Stacks
 export interface Sip009CryptoAssetInfo {
-  readonly contractAddress: string;
+  readonly contractId: string;
   readonly contractName: string;
   readonly imageCanonicalUri: string;
   readonly name: string;
@@ -57,7 +57,7 @@ export interface Sip009CryptoAssetInfo {
 
 export interface Sip010CryptoAssetInfo extends CryptoAssetInfo {
   readonly canTransfer: boolean;
-  readonly contractAddress: string;
+  readonly contractId: string;
   readonly contractName: string;
   readonly imageCanonicalUri: string;
   readonly name: string;


### PR DESCRIPTION
Made a mistake here I need fixed in my Stacks query refactor in the extension. I did not mean to remove the `contractId` from the model.