### PR TITLE
fix: add contract asset name to model

### DIFF
--- a/packages/models/src/crypto-assets/crypto-asset-info.model.ts
+++ b/packages/models/src/crypto-assets/crypto-asset-info.model.ts
@@ -60,8 +60,9 @@ export interface Sip10CryptoAssetInfo extends BaseCryptoAssetInfo {
   readonly contractId: string;
   readonly contractName: string;
   readonly contractAddress: string;
+  readonly contractAssetName: string;
   readonly imageCanonicalUri: string;
-  readonly name: string;
+  readonly tokenName: string;
   readonly symbol: string;
 }
 


### PR DESCRIPTION
We need to use specific contract asset name for post conditions  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated crypto asset information to include a new `contractAssetName` property.
  - Renamed the `name` property to `tokenName` for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->