### PR TITLE
fix: update asset models based on discussion

### DIFF
--- a/packages/models/src/crypto-assets/crypto-asset-info.model.ts
+++ b/packages/models/src/crypto-assets/crypto-asset-info.model.ts
@@ -50,7 +50,6 @@ export interface Src20CryptoAssetInfo extends BaseCryptoAssetInfo {
 // Stacks
 export interface Sip9CryptoAssetInfo {
   readonly contractId: string;
-  readonly contractName: string;
   readonly imageCanonicalUri: string;
   readonly name: string;
 }
@@ -58,11 +57,8 @@ export interface Sip9CryptoAssetInfo {
 export interface Sip10CryptoAssetInfo extends BaseCryptoAssetInfo {
   readonly canTransfer: boolean;
   readonly contractId: string;
-  readonly contractName: string;
-  readonly contractAddress: string;
-  readonly contractAssetName: string;
   readonly imageCanonicalUri: string;
-  readonly tokenName: string;
+  readonly name: string;
   readonly symbol: string;
 }
 


### PR DESCRIPTION
Based on Slack discussion, we are only going to keep `contractId` on the asset models. I will install and track updates in the extension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the `Sip9CryptoAssetInfo` and `Sip10CryptoAssetInfo` models by removing redundant properties and adding a more descriptive `name` property to `Sip10CryptoAssetInfo`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->