### PR TITLE
fix(rpc): do not augment global type implicitly

### DIFF
--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -1,3 +1,18 @@
 # @leather-wallet/rpc
 
 This package provides Typescript typings Leather developers can use when interacting with the `LeatherProvider` global object.
+
+## Consuming as global object
+
+In your Typescript project, import `LeatherProvider` and declare it as a global type.
+
+```ts
+import { LeatherProvider } from '@leather-wallet/rpc';
+
+declare global {
+  interface Window {
+    LeatherProvider?: LeatherProvider;
+  }
+}
+```
+

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -39,6 +39,19 @@ export interface ListenFn {
   (method: string, callback: () => void): () => void;
 }
 
+/**
+ * Leather's provider object set on webpage global `window` object. Set this as
+ * a global type object in your project.
+ *
+ * @example
+ * ```
+ * declare global {
+ *   interface Window {
+ *     LeatherProvider?: LeatherProvider;
+ *   }
+ * }
+ * ```
+ */
 export interface LeatherProvider {
   /**
    * Request method. Takes a method name, and optional parameters
@@ -50,10 +63,4 @@ export interface LeatherProvider {
    * @returns An unsubscribe function
    */
   listen: ListenFn;
-}
-
-declare global {
-  interface Window {
-    LeatherProvider?: LeatherProvider;
-  }
 }


### PR DESCRIPTION
Reading up on Typescript bundles, we shouldn't implicitly augment the global object. It might not be desired, can cause performance issues, and is prohibited by some tools.

Here, I've removed the global augmentation, and added README and TSDoc comments to explain how to use the provider object.

![image](https://github.com/leather-wallet/mono/assets/1618764/41239506-8154-4461-8aee-10249323c422)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added Typescript typings for the `LeatherProvider` global object in the `@leather-wallet/rpc` package.
  - Updated documentation to guide developers on using `LeatherProvider` in a Typescript project.
  - Documented the `LeatherProvider` interface and its integration with the global `window` object.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->