### PR TITLE
fix: React.JSX deprecated

### DIFF
--- a/packages/models/src/transactions/stacks-transaction.model.ts
+++ b/packages/models/src/transactions/stacks-transaction.model.ts
@@ -15,7 +15,7 @@ export interface FtTransfer {
 
 export interface TxTransferDetails {
   caption: string;
-  icon: React.JSX.Element;
+  icon: React.ReactNode;
   link: string;
   title: string;
   value: number | string | null;


### PR DESCRIPTION
Team @ Helios on TG are complaining they're running into a build error because React.JSX isn't exported in older versions of react. ReactNode should work though.

because rpc depends on models.

Our models package shouldn't depend on react though, a larger problem here 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the `icon` property type in transaction details for better flexibility and compatibility with various React components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->