### PR TITLE
fix: @leather-wallet sorting in prettier

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -3,11 +3,12 @@ import { StatusBar } from 'react-native';
 
 import { queryClient } from '@/queries/query';
 import { usePersistedStore, useProtectedStore } from '@/state';
-import { Box, ThemeProvider, useLoadFonts } from '@leather-wallet/ui/native';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import LottieView from 'lottie-react-native';
+
+import { Box, ThemeProvider, useLoadFonts } from '@leather-wallet/ui/native';
 
 void SplashScreen.preventAutoHideAsync();
 

--- a/apps/mobile/src/components/button.tsx
+++ b/apps/mobile/src/components/button.tsx
@@ -2,7 +2,6 @@ import { ComponentPropsWithoutRef, ReactNode, forwardRef } from 'react';
 import { TouchableOpacity as RNTouchableOpacity } from 'react-native';
 import Animated from 'react-native-reanimated';
 
-import { Text, Theme, TouchableOpacity } from '@leather-wallet/ui/native';
 import {
   BaseTheme,
   LayoutProps,
@@ -20,6 +19,8 @@ import {
   useRestyle,
   visible,
 } from '@shopify/restyle';
+
+import { Text, Theme, TouchableOpacity } from '@leather-wallet/ui/native';
 
 const buttonRestyleFunctions = [opacity, visible, spacing, spacingShorthand, layout];
 

--- a/apps/mobile/src/components/text-input.tsx
+++ b/apps/mobile/src/components/text-input.tsx
@@ -1,7 +1,6 @@
 import { ComponentPropsWithoutRef, ReactNode } from 'react';
 import { TextInput as RNTextInput } from 'react-native';
 
-import { Box, Text, Theme, TextInput as UITextInput } from '@leather-wallet/ui/native';
 import {
   BaseTheme,
   LayoutProps,
@@ -19,6 +18,8 @@ import {
   useTheme,
   visible,
 } from '@shopify/restyle';
+
+import { Box, Text, Theme, TextInput as UITextInput } from '@leather-wallet/ui/native';
 
 const inputRestyleFunctions = [opacity, visible, spacing, spacingShorthand, layout];
 

--- a/apps/mobile/src/components/welcome-screen/index.tsx
+++ b/apps/mobile/src/components/welcome-screen/index.tsx
@@ -9,10 +9,11 @@ import { InputState, TextInput } from '@/components/text-input';
 import { BROWSER_EXTENSION_LINK, TWITTER_LINK } from '@/constants';
 import { useFormSubmission } from '@/queries/use-form-submissions';
 import { emailRegexp } from '@/utils/regexp';
-import { Box, Text, Theme } from '@leather-wallet/ui/native';
 import { useTheme } from '@shopify/restyle';
 import * as Linking from 'expo-linking';
 import LottieView from 'lottie-react-native';
+
+import { Box, Text, Theme } from '@leather-wallet/ui/native';
 
 import { WelcomeScreenTestIds } from '../../../test-ids';
 import {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dependency-cruiser": "16.2.4",
     "eslint": "8.53.0",
     "husky": "8.0.3",
-    "prettier": "3.2.5",
+    "prettier": "3.3.0",
     "syncpack": "12.3.0",
     "turbo": "1.13.3",
     "typescript": "5.3.3"

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -52,7 +52,7 @@
     "@leather-wallet/tsconfig-config": "workspace:*",
     "@vitest/coverage-istanbul": "0.34.6",
     "eslint": "8.53.0",
-    "prettier": "3.2.5",
+    "prettier": "3.3.0",
     "tslib": "2.6.2",
     "tsup": "8.1.0",
     "typescript": "5.3.3",

--- a/packages/bitcoin/src/bip322/bip322-utils.ts
+++ b/packages/bitcoin/src/bip322/bip322-utils.ts
@@ -1,11 +1,12 @@
 import ecc from '@bitcoinerlab/secp256k1';
-import type { PaymentTypes } from '@leather-wallet/rpc';
-import { isString } from '@leather-wallet/utils';
 import { sha256 } from '@noble/hashes/sha256';
 import { hexToBytes, utf8ToBytes } from '@stacks/common';
 import * as bitcoin from 'bitcoinjs-lib';
 import { ECPairFactory } from 'ecpair';
 import { encode } from 'varuint-bitcoin';
+
+import type { PaymentTypes } from '@leather-wallet/rpc';
+import { isString } from '@leather-wallet/utils';
 
 import { toXOnly } from '../bitcoin.utils';
 

--- a/packages/bitcoin/src/bip322/sign-message-bip322-bitcoinjs.ts
+++ b/packages/bitcoin/src/bip322/sign-message-bip322-bitcoinjs.ts
@@ -1,6 +1,7 @@
-import { BitcoinNetworkModes } from '@leather-wallet/models';
 import { base64 } from '@scure/base';
 import * as bitcoin from 'bitcoinjs-lib';
+
+import { BitcoinNetworkModes } from '@leather-wallet/models';
 
 import { getBitcoinJsLibNetworkConfigByMode } from '../bitcoin.network';
 import {

--- a/packages/bitcoin/src/bitcoin-signer.ts
+++ b/packages/bitcoin/src/bitcoin-signer.ts
@@ -1,8 +1,9 @@
-import type { BitcoinNetworkModes } from '@leather-wallet/models';
-import { SignatureHash } from '@leather-wallet/rpc';
 import { HDKey } from '@scure/bip32';
 import * as btc from '@scure/btc-signer';
 import { SigHash } from '@scure/btc-signer/transaction';
+
+import type { BitcoinNetworkModes } from '@leather-wallet/models';
+import { SignatureHash } from '@leather-wallet/rpc';
 
 export type AllowedSighashTypes = SignatureHash | SigHash;
 

--- a/packages/bitcoin/src/bitcoin.network.ts
+++ b/packages/bitcoin/src/bitcoin.network.ts
@@ -1,5 +1,6 @@
-import { BitcoinNetworkModes } from '@leather-wallet/models';
 import * as bitcoinJs from 'bitcoinjs-lib';
+
+import { BitcoinNetworkModes } from '@leather-wallet/models';
 
 // See this PR https://github.com/paulmillr/@scure/btc-signer/pull/15
 // Atttempting to add these directly to the library

--- a/packages/bitcoin/src/bitcoin.utils.ts
+++ b/packages/bitcoin/src/bitcoin.utils.ts
@@ -1,11 +1,12 @@
-import { DerivationPathDepth, extractAccountIndexFromPath } from '@leather-wallet/crypto';
-import { BitcoinNetworkModes, NetworkModes } from '@leather-wallet/models';
-import type { PaymentTypes } from '@leather-wallet/rpc';
-import { defaultWalletKeyId, whenNetwork } from '@leather-wallet/utils';
 import { hexToBytes } from '@noble/hashes/utils';
 import { HDKey, Versions } from '@scure/bip32';
 import { mnemonicToSeedSync } from '@scure/bip39';
 import * as btc from '@scure/btc-signer';
+
+import { DerivationPathDepth, extractAccountIndexFromPath } from '@leather-wallet/crypto';
+import { BitcoinNetworkModes, NetworkModes } from '@leather-wallet/models';
+import type { PaymentTypes } from '@leather-wallet/rpc';
+import { defaultWalletKeyId, whenNetwork } from '@leather-wallet/utils';
 
 import { BtcSignerNetwork } from './bitcoin.network';
 import { getTaprootPayment } from './p2tr-address-gen';

--- a/packages/bitcoin/src/p2tr-address-gen.ts
+++ b/packages/bitcoin/src/p2tr-address-gen.ts
@@ -1,7 +1,8 @@
-import { DerivationPathDepth } from '@leather-wallet/crypto';
-import { BitcoinNetworkModes } from '@leather-wallet/models';
 import { HDKey } from '@scure/bip32';
 import * as btc from '@scure/btc-signer';
+
+import { DerivationPathDepth } from '@leather-wallet/crypto';
+import { BitcoinNetworkModes } from '@leather-wallet/models';
 
 import { getBtcSignerLibNetworkConfigByMode } from './bitcoin.network';
 import {

--- a/packages/bitcoin/src/p2wpkh-address-gen.ts
+++ b/packages/bitcoin/src/p2wpkh-address-gen.ts
@@ -1,7 +1,8 @@
-import { DerivationPathDepth } from '@leather-wallet/crypto';
-import { BitcoinNetworkModes } from '@leather-wallet/models';
 import { HDKey } from '@scure/bip32';
 import * as btc from '@scure/btc-signer';
+
+import { DerivationPathDepth } from '@leather-wallet/crypto';
+import { BitcoinNetworkModes } from '@leather-wallet/models';
 
 import { getBtcSignerLibNetworkConfigByMode } from './bitcoin.network';
 import {

--- a/packages/bitcoin/src/p2wsh-p2sh-address-gen.ts
+++ b/packages/bitcoin/src/p2wsh-p2sh-address-gen.ts
@@ -1,8 +1,9 @@
-import { deriveBip39MnemonicFromSeed, deriveRootBip32Keychain } from '@leather-wallet/crypto';
-import { NetworkModes } from '@leather-wallet/models';
 import { ripemd160 } from '@noble/hashes/ripemd160';
 import { sha256 } from '@noble/hashes/sha256';
 import { base58check } from '@scure/base';
+
+import { deriveBip39MnemonicFromSeed, deriveRootBip32Keychain } from '@leather-wallet/crypto';
+import { NetworkModes } from '@leather-wallet/models';
 
 /**
  * @deprecated

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -30,7 +30,7 @@
     "@leather-wallet/tsconfig-config": "workspace:*",
     "concurrently": "8.2.2",
     "eslint": "8.53.0",
-    "prettier": "3.2.5",
+    "prettier": "3.3.0",
     "tsup": "8.1.0",
     "typescript": "5.3.3"
   },

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -34,7 +34,7 @@
     "@types/react": "18.2.79",
     "concurrently": "8.2.2",
     "eslint": "8.53.0",
-    "prettier": "3.2.5",
+    "prettier": "3.3.0",
     "tsup": "8.1.0",
     "typescript": "5.3.3"
   },

--- a/packages/prettier-config/.prettierrc.js
+++ b/packages/prettier-config/.prettierrc.js
@@ -14,6 +14,7 @@ export default {
   importOrder: [
     '^react',
     '<THIRD_PARTY_MODULES>',
+    '^@leather-wallet/(.*)$',
     '^@shared/(.*)$',
     '^@(app|content-script|inpage|background)/(.*)$',
     '^[./]',

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -14,7 +14,7 @@
   "bugs": "https://github.com/leather-wallet/mono/issues",
   "dependencies": {
     "@trivago/prettier-plugin-sort-imports": "4.3.0",
-    "prettier": "3.2.5"
+    "prettier": "3.3.0"
   },
   "keywords": [
     "leather",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -67,7 +67,7 @@
     "concurrently": "8.2.2",
     "eslint": "8.53.0",
     "jsdom": "22.1.0",
-    "prettier": "3.2.5",
+    "prettier": "3.3.0",
     "tsup": "8.1.0",
     "typescript": "5.3.3",
     "vitest": "0.34.6"

--- a/packages/query/src/bitcoin/address/transactions-by-address.query.ts
+++ b/packages/query/src/bitcoin/address/transactions-by-address.query.ts
@@ -1,5 +1,6 @@
-import type { BitcoinTx } from '@leather-wallet/models';
 import { QueryFunctionContext, useQueries, useQuery } from '@tanstack/react-query';
+
+import type { BitcoinTx } from '@leather-wallet/models';
 
 import { AppUseQueryConfig } from '../../query-config';
 import { useBitcoinClient } from '../bitcoin-client';

--- a/packages/query/src/bitcoin/address/utxos-by-address.query.ts
+++ b/packages/query/src/bitcoin/address/utxos-by-address.query.ts
@@ -1,10 +1,11 @@
+import { HDKey } from '@scure/bip32';
+import { useQuery } from '@tanstack/react-query';
+
 import {
   getNativeSegwitAddressIndexDerivationPath,
   getTaprootAddress,
 } from '@leather-wallet/bitcoin';
 import { createCounter } from '@leather-wallet/utils';
-import { HDKey } from '@scure/bip32';
-import { useQuery } from '@tanstack/react-query';
 
 import { UtxoResponseItem, UtxoWithDerivationPath } from '../../../types/utxo';
 import { useLeatherNetwork } from '../../leather-query-provider';

--- a/packages/query/src/bitcoin/balance/btc-balance.hooks.ts
+++ b/packages/query/src/bitcoin/balance/btc-balance.hooks.ts
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
 
-import { createMoney, isUndefined, sumNumbers } from '@leather-wallet/utils';
 import BigNumber from 'bignumber.js';
+
+import { createMoney, isUndefined, sumNumbers } from '@leather-wallet/utils';
 
 import { useNativeSegwitUtxosByAddress } from '../address/utxos-by-address.hooks';
 import { useRunesEnabled } from '../runes/runes.hooks';

--- a/packages/query/src/bitcoin/balance/btc-taproot-balance.hooks.ts
+++ b/packages/query/src/bitcoin/balance/btc-taproot-balance.hooks.ts
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
 
-import { createMoney, sumNumbers } from '@leather-wallet/utils';
 import { HDKey } from '@scure/bip32';
+
+import { createMoney, sumNumbers } from '@leather-wallet/utils';
 
 import { UtxoWithDerivationPath } from '../../../types/utxo';
 import { filterUtxosWithInscriptions } from '../address/utxos-by-address.hooks';

--- a/packages/query/src/bitcoin/bitcoin-client.ts
+++ b/packages/query/src/bitcoin/bitcoin-client.ts
@@ -1,3 +1,5 @@
+import axios from 'axios';
+
 import {
   BESTINSLOT_API_BASE_URL_MAINNET,
   BESTINSLOT_API_BASE_URL_TESTNET,
@@ -6,7 +8,6 @@ import {
   MarketData,
   Money,
 } from '@leather-wallet/models';
-import axios from 'axios';
 
 import { UtxoResponseItem } from '../../types/utxo';
 import { useLeatherNetwork } from '../leather-query-provider';

--- a/packages/query/src/bitcoin/blockstream-rate-limiter.ts
+++ b/packages/query/src/bitcoin/blockstream-rate-limiter.ts
@@ -1,5 +1,6 @@
-import { BITCOIN_API_BASE_URL_TESTNET } from '@leather-wallet/models';
 import PQueue from 'p-queue';
+
+import { BITCOIN_API_BASE_URL_TESTNET } from '@leather-wallet/models';
 
 const blockstreamMainnetApiLimiter = new PQueue({
   interval: 5000,

--- a/packages/query/src/bitcoin/fees/fee-estimates.query.ts
+++ b/packages/query/src/bitcoin/fees/fee-estimates.query.ts
@@ -1,5 +1,6 @@
-import { BitcoinNetworkModes } from '@leather-wallet/models';
 import { useQuery } from '@tanstack/react-query';
+
+import { BitcoinNetworkModes } from '@leather-wallet/models';
 
 import { useLeatherNetwork } from '../../leather-query-provider';
 import { AppUseQueryConfig } from '../../query-config';

--- a/packages/query/src/bitcoin/ordinals/brc20/brc20-tokens.query.ts
+++ b/packages/query/src/bitcoin/ordinals/brc20/brc20-tokens.query.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect } from 'react';
 
-import type { Signer } from '@leather-wallet/bitcoin';
-import { createNumArrayOfRange } from '@leather-wallet/utils';
 import { P2TROut } from '@scure/btc-signer/payment';
 import { useInfiniteQuery } from '@tanstack/react-query';
+
+import type { Signer } from '@leather-wallet/bitcoin';
+import { createNumArrayOfRange } from '@leather-wallet/utils';
 
 import { useLeatherNetwork } from '../../../leather-query-provider';
 import { QueryPrefixes } from '../../../query-prefixes';

--- a/packages/query/src/bitcoin/ordinals/inscription-by-id.query.ts
+++ b/packages/query/src/bitcoin/ordinals/inscription-by-id.query.ts
@@ -1,5 +1,6 @@
-import { HIRO_INSCRIPTIONS_API_URL } from '@leather-wallet/models';
 import axios from 'axios';
+
+import { HIRO_INSCRIPTIONS_API_URL } from '@leather-wallet/models';
 
 import { InscriptionResponseHiro } from '../../../types/inscription';
 

--- a/packages/query/src/bitcoin/ordinals/inscription.query.ts
+++ b/packages/query/src/bitcoin/ordinals/inscription.query.ts
@@ -1,6 +1,7 @@
-import { HIRO_INSCRIPTIONS_API_URL } from '@leather-wallet/models';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+
+import { HIRO_INSCRIPTIONS_API_URL } from '@leather-wallet/models';
 
 import { InscriptionResponseHiro } from '../../../types/inscription';
 import { AppUseQueryConfig } from '../../query-config';

--- a/packages/query/src/bitcoin/ordinals/inscriptions-by-param.hooks.ts
+++ b/packages/query/src/bitcoin/ordinals/inscriptions-by-param.hooks.ts
@@ -1,6 +1,7 @@
+import { TransactionInput } from '@scure/btc-signer/psbt';
+
 import { BitcoinTx } from '@leather-wallet/models';
 import { isUndefined } from '@leather-wallet/utils';
-import { TransactionInput } from '@scure/btc-signer/psbt';
 
 import { InscriptionResponseHiro } from '../../../types/inscription';
 import { createInscriptionHiro } from './inscription.utils';

--- a/packages/query/src/bitcoin/ordinals/inscriptions-by-param.query.ts
+++ b/packages/query/src/bitcoin/ordinals/inscriptions-by-param.query.ts
@@ -1,9 +1,10 @@
-import { BitcoinTx } from '@leather-wallet/models';
-import { HIRO_INSCRIPTIONS_API_URL } from '@leather-wallet/models';
 import { TransactionInput } from '@scure/btc-signer/psbt';
 import { bytesToHex } from '@stacks/common';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+
+import { BitcoinTx } from '@leather-wallet/models';
+import { HIRO_INSCRIPTIONS_API_URL } from '@leather-wallet/models';
 
 import { Paginated } from '../../../types/api-types';
 import { InscriptionResponseHiro } from '../../../types/inscription';

--- a/packages/query/src/bitcoin/ordinals/inscriptions.hooks.ts
+++ b/packages/query/src/bitcoin/ordinals/inscriptions.hooks.ts
@@ -1,7 +1,8 @@
 import { useCallback } from 'react';
 
-import { isUndefined } from '@leather-wallet/utils';
 import { HDKey } from '@scure/bip32';
+
+import { isUndefined } from '@leather-wallet/utils';
 
 import { InscriptionResponseHiro } from '../../../types/inscription';
 import { createInscriptionHiro } from './inscription.utils';

--- a/packages/query/src/bitcoin/ordinals/inscriptions.query.ts
+++ b/packages/query/src/bitcoin/ordinals/inscriptions.query.ts
@@ -1,12 +1,13 @@
 import { useCallback, useEffect } from 'react';
 
+import { HDKey } from '@scure/bip32';
+import { UseInfiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
 import { getTaprootAddress } from '@leather-wallet/bitcoin';
 import { HIRO_INSCRIPTIONS_API_URL } from '@leather-wallet/models';
 import { createNumArrayOfRange } from '@leather-wallet/utils';
 import { ensureArray } from '@leather-wallet/utils';
-import { HDKey } from '@scure/bip32';
-import { UseInfiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query';
-import axios from 'axios';
 
 import type { InscriptionResponseHiro } from '../../../types/inscription';
 import { useHiroApiRateLimiter } from '../../hiro-rate-limiter';

--- a/packages/query/src/bitcoin/runes/runes-ticker-info.query.ts
+++ b/packages/query/src/bitcoin/runes/runes-ticker-info.query.ts
@@ -1,5 +1,6 @@
-import { isDefined } from '@leather-wallet/utils';
 import { useQueries } from '@tanstack/react-query';
+
+import { isDefined } from '@leather-wallet/utils';
 
 import { useLeatherNetwork } from '../../leather-query-provider';
 import { RuneBalance, type RuneTickerInfo, useBitcoinClient } from '../bitcoin-client';

--- a/packages/query/src/bitcoin/stamps/stamps-by-address.hooks.ts
+++ b/packages/query/src/bitcoin/stamps/stamps-by-address.hooks.ts
@@ -1,6 +1,7 @@
+import BigNumber from 'bignumber.js';
+
 import { Src20CryptoAssetInfo, createCryptoAssetBalance } from '@leather-wallet/models';
 import { createMoney } from '@leather-wallet/utils';
-import BigNumber from 'bignumber.js';
 
 import { Src20Token, useStampsByAddressQuery } from './stamps-by-address.query';
 

--- a/packages/query/src/bitcoin/transaction/transaction.query.ts
+++ b/packages/query/src/bitcoin/transaction/transaction.query.ts
@@ -1,5 +1,6 @@
-import { BitcoinTx } from '@leather-wallet/models';
 import { UseQueryResult, useQueries, useQuery } from '@tanstack/react-query';
+
+import { BitcoinTx } from '@leather-wallet/models';
 
 import { AppUseQueryConfig } from '../../query-config';
 import { BitcoinClient, useBitcoinClient } from '../bitcoin-client';

--- a/packages/query/src/bitcoin/transaction/use-bitcoin-broadcast-transaction.ts
+++ b/packages/query/src/bitcoin/transaction/use-bitcoin-broadcast-transaction.ts
@@ -1,8 +1,9 @@
 import { useCallback, useState } from 'react';
 
+import { TransactionInput } from '@scure/btc-signer/psbt';
+
 import { decodeBitcoinTx } from '@leather-wallet/bitcoin';
 import { delay } from '@leather-wallet/utils';
-import { TransactionInput } from '@scure/btc-signer/psbt';
 
 import { useBitcoinClient } from '../bitcoin-client';
 import { filterOutIntentionalUtxoSpend, useCheckUnspendableUtxos } from './use-check-utxos';

--- a/packages/query/src/bitcoin/transaction/use-check-utxos.ts
+++ b/packages/query/src/bitcoin/transaction/use-check-utxos.ts
@@ -1,8 +1,9 @@
 import { useCallback, useState } from 'react';
 
-import { isUndefined } from '@leather-wallet/utils';
 import { TransactionInput } from '@scure/btc-signer/psbt';
 import { bytesToHex } from '@stacks/common';
+
+import { isUndefined } from '@leather-wallet/utils';
 
 import { useCurrentNetworkState, useIsLeatherTestingEnv } from '../../leather-query-provider';
 import { BitcoinClient, useBitcoinClient } from '../bitcoin-client';

--- a/packages/query/src/common/market-data/market-data.hooks.ts
+++ b/packages/query/src/common/market-data/market-data.hooks.ts
@@ -1,5 +1,7 @@
 import { useCallback, useMemo } from 'react';
 
+import BigNumber from 'bignumber.js';
+
 import { currencyDecimalsMap } from '@leather-wallet/constants';
 import {
   CryptoCurrencies,
@@ -14,7 +16,6 @@ import {
   convertAmountToFractionalUnit,
   createMoney,
 } from '@leather-wallet/utils';
-import BigNumber from 'bignumber.js';
 
 import {
   selectBinanceUsdPrice,

--- a/packages/query/src/common/market-data/vendors/binance-market-data.query.ts
+++ b/packages/query/src/common/market-data/vendors/binance-market-data.query.ts
@@ -1,6 +1,7 @@
-import { CryptoCurrencies } from '@leather-wallet/models';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+
+import { CryptoCurrencies } from '@leather-wallet/models';
 
 import { marketDataQueryOptions } from '../market-data.query';
 

--- a/packages/query/src/common/market-data/vendors/coincap-market-data.query.ts
+++ b/packages/query/src/common/market-data/vendors/coincap-market-data.query.ts
@@ -1,6 +1,7 @@
-import { CryptoCurrencies } from '@leather-wallet/models';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+
+import { CryptoCurrencies } from '@leather-wallet/models';
 
 import { marketDataQueryOptions } from '../market-data.query';
 

--- a/packages/query/src/common/market-data/vendors/coingecko-market-data.query.ts
+++ b/packages/query/src/common/market-data/vendors/coingecko-market-data.query.ts
@@ -1,6 +1,7 @@
-import { CryptoCurrencies } from '@leather-wallet/models';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+
+import { CryptoCurrencies } from '@leather-wallet/models';
 
 import { marketDataQueryOptions } from '../market-data.query';
 

--- a/packages/query/src/common/remote-config/remote-config.query.ts
+++ b/packages/query/src/common/remote-config/remote-config.query.ts
@@ -1,7 +1,8 @@
-import { createMoney, isUndefined } from '@leather-wallet/utils';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import get from 'lodash.get';
+
+import { createMoney, isUndefined } from '@leather-wallet/utils';
 
 import type { ActiveFiatProvider, HiroMessage, RemoteConfig } from '../../../types/remote-config';
 import { LeatherEnvironment, useLeatherEnv, useLeatherGithub } from '../../leather-query-provider';

--- a/packages/query/src/leather-query-provider.tsx
+++ b/packages/query/src/leather-query-provider.tsx
@@ -1,8 +1,9 @@
 import { ReactNode, createContext, useContext, useMemo } from 'react';
 
-import { NetworkConfiguration, NetworkModes } from '@leather-wallet/models';
 import { ChainID } from '@stacks/common';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { NetworkConfiguration, NetworkModes } from '@leather-wallet/models';
 
 import type { RemoteConfig } from '../types/remote-config';
 

--- a/packages/query/types/account.ts
+++ b/packages/query/types/account.ts
@@ -1,5 +1,6 @@
-import type { Money } from '@leather-wallet/models';
 import { AddressTokenOfferingLocked } from '@stacks/stacks-blockchain-api-types/generated';
+
+import type { Money } from '@leather-wallet/models';
 
 type SelectedKeys =
   | 'balance'

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -25,7 +25,7 @@
     "@leather-wallet/eslint-config": "workspace:*",
     "@leather-wallet/prettier-config": "workspace:*",
     "@leather-wallet/tsconfig-config": "workspace:*",
-    "prettier": "3.2.5",
+    "prettier": "3.3.0",
     "tsup": "8.1.0"
   },
   "keywords": [

--- a/packages/ui/src/theme-native/theme.tsx
+++ b/packages/ui/src/theme-native/theme.tsx
@@ -1,7 +1,8 @@
 import { ColorSchemeName } from 'react-native';
 
-import { AllThemePalette, colorThemes, getMobileTextVariants } from '@leather-wallet/tokens';
 import { ThemeProvider as ThemeProviderRestyle, createTheme } from '@shopify/restyle';
+
+import { AllThemePalette, colorThemes, getMobileTextVariants } from '@leather-wallet/tokens';
 
 const textVariants = getMobileTextVariants();
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -38,7 +38,7 @@
     "@leather-wallet/tsconfig-config": "workspace:*",
     "@vitest/coverage-istanbul": "0.34.6",
     "eslint": "8.53.0",
-    "prettier": "3.2.5",
+    "prettier": "3.3.0",
     "tsup": "8.1.0",
     "typescript": "5.3.3",
     "vitest": "0.34.6"

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,6 @@
-import type { NetworkModes } from '@leather-wallet/models';
 import { BigNumber } from 'bignumber.js';
+
+import type { NetworkModes } from '@leather-wallet/models';
 
 export { createCounter } from './counter';
 export * from './math';

--- a/packages/utils/src/money/calculate-money.spec.ts
+++ b/packages/utils/src/money/calculate-money.spec.ts
@@ -1,5 +1,6 @@
-import { MarketData, createMarketData, createMarketPair } from '@leather-wallet/models';
 import BigNumber from 'bignumber.js';
+
+import { MarketData, createMarketData, createMarketPair } from '@leather-wallet/models';
 
 import {
   baseCurrencyAmountInQuote,

--- a/packages/utils/src/money/calculate-money.ts
+++ b/packages/utils/src/money/calculate-money.ts
@@ -1,6 +1,7 @@
+import { BigNumber } from 'bignumber.js';
+
 import type { MarketData, Money, NumType } from '@leather-wallet/models';
 import { formatMarketPair } from '@leather-wallet/models';
-import { BigNumber } from 'bignumber.js';
 
 import { isNumber } from '..';
 import { initBigNumber, sumNumbers } from '../math/helpers';

--- a/packages/utils/src/money/format-money.ts
+++ b/packages/utils/src/money/format-money.ts
@@ -1,6 +1,7 @@
+import BigNumber from 'bignumber.js';
+
 import { currencyDecimalsMap } from '@leather-wallet/constants';
 import type { Currencies, Money, NumType } from '@leather-wallet/models';
-import BigNumber from 'bignumber.js';
 
 import { isBigInt, isUndefined } from '..';
 

--- a/packages/utils/src/money/is-money.ts
+++ b/packages/utils/src/money/is-money.ts
@@ -1,5 +1,6 @@
-import { Money } from '@leather-wallet/models';
 import BigNumber from 'bignumber.js';
+
+import { Money } from '@leather-wallet/models';
 
 import { isObject } from '..';
 

--- a/packages/utils/src/money/unit-conversion.ts
+++ b/packages/utils/src/money/unit-conversion.ts
@@ -1,6 +1,7 @@
+import BigNumber from 'bignumber.js';
+
 import { BTC_DECIMALS, STX_DECIMALS } from '@leather-wallet/constants';
 import { Money } from '@leather-wallet/models';
-import BigNumber from 'bignumber.js';
 
 import { initBigNumber } from '../math/helpers';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,8 +47,8 @@ importers:
         specifier: 8.0.3
         version: 8.0.3
       prettier:
-        specifier: 3.2.5
-        version: 3.2.5
+        specifier: 3.3.0
+        version: 3.3.0
       syncpack:
         specifier: 12.3.0
         version: 12.3.0(typescript@5.3.3)
@@ -223,7 +223,7 @@ importers:
         version: 8.53.0
       eslint-config-universe:
         specifier: 12.0.0
-        version: 12.0.0(@types/eslint@8.56.10)(eslint@8.53.0)(prettier@3.2.5)(typescript@5.3.3)
+        version: 12.0.0(@types/eslint@8.56.10)(eslint@8.53.0)(prettier@3.3.0)(typescript@5.3.3)
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@20.14.0)
@@ -313,8 +313,8 @@ importers:
         specifier: 8.53.0
         version: 8.53.0
       prettier:
-        specifier: 3.2.5
-        version: 3.2.5
+        specifier: 3.3.0
+        version: 3.3.0
       tslib:
         specifier: 2.6.2
         version: 2.6.2
@@ -346,8 +346,8 @@ importers:
         specifier: 8.53.0
         version: 8.53.0
       prettier:
-        specifier: 3.2.5
-        version: 3.2.5
+        specifier: 3.3.0
+        version: 3.3.0
       tsup:
         specifier: 8.1.0
         version: 8.1.0(@swc/core@1.5.24)(postcss@8.4.38)(typescript@5.3.3)
@@ -414,8 +414,8 @@ importers:
         specifier: 8.53.0
         version: 8.53.0
       prettier:
-        specifier: 3.2.5
-        version: 3.2.5
+        specifier: 3.3.0
+        version: 3.3.0
       tsup:
         specifier: 8.1.0
         version: 8.1.0(@swc/core@1.5.24)(postcss@8.4.38)(typescript@5.3.3)
@@ -440,10 +440,10 @@ importers:
     dependencies:
       '@trivago/prettier-plugin-sort-imports':
         specifier: 4.3.0
-        version: 4.3.0(@vue/compiler-sfc@3.3.4)(prettier@3.2.5)
+        version: 4.3.0(@vue/compiler-sfc@3.3.4)(prettier@3.3.0)
       prettier:
-        specifier: 3.2.5
-        version: 3.2.5
+        specifier: 3.3.0
+        version: 3.3.0
 
   packages/query:
     dependencies:
@@ -554,8 +554,8 @@ importers:
         specifier: 22.1.0
         version: 22.1.0
       prettier:
-        specifier: 3.2.5
-        version: 3.2.5
+        specifier: 3.3.0
+        version: 3.3.0
       tsup:
         specifier: 8.1.0
         version: 8.1.0(@swc/core@1.5.24)(postcss@8.4.38)(typescript@5.3.3)
@@ -588,8 +588,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig-config
       prettier:
-        specifier: 3.2.5
-        version: 3.2.5
+        specifier: 3.3.0
+        version: 3.3.0
       tsup:
         specifier: 8.1.0
         version: 8.1.0(@swc/core@1.5.24)(postcss@8.4.38)(typescript@5.3.3)
@@ -746,7 +746,7 @@ importers:
         version: 8.53.0
       eslint-config-universe:
         specifier: 12.0.0
-        version: 12.0.0(@types/eslint@8.56.10)(eslint@8.53.0)(prettier@3.2.5)(typescript@5.3.3)
+        version: 12.0.0(@types/eslint@8.56.10)(eslint@8.53.0)(prettier@3.3.0)(typescript@5.3.3)
       postcss-loader:
         specifier: 8.1.1
         version: 8.1.1(postcss@8.4.38)(typescript@5.3.3)(webpack@5.91.0(@swc/core@1.5.24)(esbuild@0.18.20))
@@ -800,8 +800,8 @@ importers:
         specifier: 8.53.0
         version: 8.53.0
       prettier:
-        specifier: 3.2.5
-        version: 3.2.5
+        specifier: 3.3.0
+        version: 3.3.0
       tsup:
         specifier: 8.1.0
         version: 8.1.0(@swc/core@1.5.24)(postcss@8.4.38)(typescript@5.3.3)
@@ -2672,7 +2672,6 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
-    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -9132,8 +9131,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.2.5:
-    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
+  prettier@3.3.0:
+    resolution: {integrity: sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -11240,7 +11239,7 @@ snapshots:
 
   '@babel/generator@7.17.7':
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.24.6
       jsesc: 2.5.2
       source-map: 0.5.7
 
@@ -14052,7 +14051,7 @@ snapshots:
       lodash.merge: 4.6.2
       look-it-up: 2.1.0
       outdent: 0.8.0
-      pathe: 1.1.1
+      pathe: 1.1.2
       perfect-debounce: 1.0.0
       pkg-types: 1.0.3
       pluralize: 8.0.0
@@ -16598,7 +16597,7 @@ snapshots:
 
   '@tootallnate/once@2.0.0': {}
 
-  '@trivago/prettier-plugin-sort-imports@4.3.0(@vue/compiler-sfc@3.3.4)(prettier@3.2.5)':
+  '@trivago/prettier-plugin-sort-imports@4.3.0(@vue/compiler-sfc@3.3.4)(prettier@3.3.0)':
     dependencies:
       '@babel/generator': 7.17.7
       '@babel/parser': 7.24.6
@@ -16606,7 +16605,7 @@ snapshots:
       '@babel/types': 7.17.0
       javascript-natural-sort: 0.7.1
       lodash: 4.17.21
-      prettier: 3.2.5
+      prettier: 3.3.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.3.4
     transitivePeerDependencies:
@@ -17079,7 +17078,7 @@ snapshots:
       '@vue/reactivity-transform': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.5
+      magic-string: 0.30.10
       postcss: 8.4.38
       source-map-js: 1.2.0
 
@@ -17094,7 +17093,7 @@ snapshots:
       '@vue/compiler-core': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.5
+      magic-string: 0.30.10
 
   '@vue/shared@3.3.4': {}
 
@@ -19095,7 +19094,7 @@ snapshots:
     dependencies:
       eslint: 8.53.0
 
-  eslint-config-universe@12.0.0(@types/eslint@8.56.10)(eslint@8.53.0)(prettier@3.2.5)(typescript@5.3.3):
+  eslint-config-universe@12.0.0(@types/eslint@8.56.10)(eslint@8.53.0)(prettier@3.3.0)(typescript@5.3.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 6.9.0(@typescript-eslint/parser@6.9.0(eslint@8.53.0)(typescript@5.3.3))(eslint@8.53.0)(typescript@5.3.3)
       '@typescript-eslint/parser': 6.9.0(eslint@8.53.0)(typescript@5.3.3)
@@ -19103,11 +19102,11 @@ snapshots:
       eslint-config-prettier: 8.10.0(eslint@8.53.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.9.0(eslint@8.53.0)(typescript@5.3.3))(eslint@8.53.0)
       eslint-plugin-node: 11.1.0(eslint@8.53.0)
-      eslint-plugin-prettier: 5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@8.10.0(eslint@8.53.0))(eslint@8.53.0)(prettier@3.2.5)
+      eslint-plugin-prettier: 5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@8.10.0(eslint@8.53.0))(eslint@8.53.0)(prettier@3.3.0)
       eslint-plugin-react: 7.34.2(eslint@8.53.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.53.0)
     optionalDependencies:
-      prettier: 3.2.5
+      prettier: 3.3.0
     transitivePeerDependencies:
       - '@types/eslint'
       - eslint-import-resolver-typescript
@@ -19186,10 +19185,10 @@ snapshots:
       resolve: 1.22.8
       semver: 6.3.1
 
-  eslint-plugin-prettier@5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@8.10.0(eslint@8.53.0))(eslint@8.53.0)(prettier@3.2.5):
+  eslint-plugin-prettier@5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@8.10.0(eslint@8.53.0))(eslint@8.53.0)(prettier@3.3.0):
     dependencies:
       eslint: 8.53.0
-      prettier: 3.2.5
+      prettier: 3.3.0
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.8
     optionalDependencies:
@@ -19436,12 +19435,12 @@ snapshots:
   ? expo-file-system@17.0.1(expo@51.0.8(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.1(expo@51.0.8(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.1)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.3.3)))(expo-linking@6.3.1(expo@51.0.8))(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.3.3))
   : dependencies:
       expo: 51.0.8(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.1(expo@51.0.8(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.1)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.3.3)))(expo-linking@6.3.1(expo@51.0.8))(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
-      expo-modules-core: 1.12.11
+      expo-modules-core: 1.12.12
 
   expo-file-system@17.0.1(expo@51.0.8(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.1)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.3.3)):
     dependencies:
       expo: 51.0.8(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.1)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
-      expo-modules-core: 1.12.11
+      expo-modules-core: 1.12.12
 
   ? expo-font@12.0.5(expo@51.0.8(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.1(expo@51.0.8(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.1)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.3.3)))(expo-linking@6.3.1(expo@51.0.8))(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.3.3))
   : dependencies:
@@ -19471,12 +19470,12 @@ snapshots:
   ? expo-keep-awake@13.0.2(expo@51.0.8(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.1(expo@51.0.8(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.1)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.3.3)))(expo-linking@6.3.1(expo@51.0.8))(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.3.3))
   : dependencies:
       expo: 51.0.8(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.1(expo@51.0.8(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.1)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.3.3)))(expo-linking@6.3.1(expo@51.0.8))(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
-      expo-modules-core: 1.12.11
+      expo-modules-core: 1.12.12
 
   expo-keep-awake@13.0.2(expo@51.0.8(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.1)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.3.3)):
     dependencies:
       expo: 51.0.8(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(expo-constants@16.0.1)(expo-linking@6.3.1)(expo-status-bar@1.12.1)(react-dom@18.2.0(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.6)(@babel/preset-env@7.24.6(@babel/core@7.24.6))(@react-native/assets-registry@0.73.1)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
-      expo-modules-core: 1.12.11
+      expo-modules-core: 1.12.12
 
   expo-linking@6.3.1(expo@51.0.8):
     dependencies:
@@ -22505,7 +22504,7 @@ snapshots:
     dependencies:
       jsonc-parser: 3.2.1
       mlly: 1.7.0
-      pathe: 1.1.1
+      pathe: 1.1.2
 
   pkg-types@1.1.1:
     dependencies:
@@ -22836,7 +22835,7 @@ snapshots:
 
   prettier@2.8.8: {}
 
-  prettier@3.2.5: {}
+  prettier@3.3.0: {}
 
   pretty-bytes@5.6.0: {}
 


### PR DESCRIPTION
Adds a separate sorting for `@leather-wallet/*` packages, [as recently polled in Slack](https://trustmachines.slack.com/archives/C05LAP952E7/p1717516338516209)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated `prettier` version from `3.2.5` to `3.3.0` across multiple packages.
  - Added new import order rule for modules starting with `@leather-wallet/` in `.prettierrc.js`.

- **Refactor**
  - Reordered import statements in various files to improve code organization and maintain consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->