### PR TITLE
ci: check file formatting

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/provision
       - name: Lint Prettier
-        run: pnpm format
+        run: pnpm format:check
 
   lint-syncpack:
     runs-on: ubuntu-latest

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -12,6 +12,7 @@
     "eas-build-post-install": "cd ../.. && pnpm build",
     "eas-build-pre-install": "./eas-hooks/eas-build-pre-install.sh",
     "format": "prettier --write \"src/**/*.{ts,tsx}\" --ignore-path ../../.prettierignore",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx}\" --ignore-path ../../.prettierignore",
     "ios": "expo run:ios",
     "ios:build": "expo run:ios --no-bundler",
     "lint": "eslint . --ignore-path ../../.eslintignore",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "clean": "git clean -dfX",
     "dev": "turbo run build:watch",
     "format": "turbo run format",
+    "format:check": "turbo run format:check",
     "install:clean": "rm -rf \"**/node_modules\" && pnpm -r clean",
     "install:fresh": "pnpm install:clean && pnpm i",
     "install:nuke": "rm -rf pnpm-lock.yaml && pnpm install:fresh",

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -15,6 +15,7 @@
     "build": "tsup",
     "build:watch": "tsup --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
+    "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint . --fix --ignore-path ../../.eslintignore",
     "lint:fix": "eslint . --fix --ignore-path ../../.eslintignore",
     "test:coverage": "vitest run --coverage",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -15,6 +15,7 @@
     "build": "tsup ",
     "build:watch": "tsup --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
+    "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint . --ignore-path ../../.eslintignore",
     "lint:fix": "eslint . --fix --ignore-path ../../.eslintignore",
     "typecheck": "tsc --noEmit"

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -15,6 +15,7 @@
     "build": "tsup",
     "build:watch": "tsup --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
+    "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint . --ignore-path ../../.eslintignore",
     "lint:fix": "eslint . --fix --ignore-path ../../.eslintignore",
     "typecheck": "tsc --noEmit -p ./tsconfig.json"

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -15,6 +15,7 @@
     "build": "tsup index.ts --format esm && tsc --emitDeclarationOnly",
     "build:watch": "concurrently  \"tsc --build --watch --preserveWatchOutput --emitDeclarationOnly\"  \"tsup index.ts --format esm --watch \"  ",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
+    "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint . --ignore-path ../../.eslintignore",
     "lint:fix": "eslint . --fix --ignore-path ../../.eslintignore",
     "test:coverage": "vitest run --coverage",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,6 +12,7 @@
     "build:watch": "concurrently  \"pnpm panda:watch\"  \"pnpm build:native --watch --preserveWatchOutput\"  \"pnpm build:web --watch --preserveWatchOutput\"  \"pnpm build:all --watch --preserveWatchOutput\" ",
     "build:web": "pnpm assets:web && tsc -p ./tsconfig.web.json",
     "format": "prettier . --write \"src/**/*.{ts,tsx}\" --ignore-path ../../.prettierignore",
+    "format:check": "prettier . --check \"src/**/*.{ts,tsx}\" --ignore-path ../../.prettierignore",
     "lint": "eslint . --ignore-path ../../.eslintignore",
     "lint:fix": "eslint . --fix --ignore-path ../../.eslintignore",
     "panda": "panda codegen -c ./panda.config.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -15,6 +15,7 @@
     "build": "tsup",
     "build:watch": "tsup --watch",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
+    "format:check": "prettier . --check --ignore-path ../../.prettierignore",
     "lint": "eslint . --ignore-path ../../.eslintignore",
     "lint:fix": "eslint . --fix --ignore-path ../../.eslintignore",
     "test:coverage": "vitest run --coverage",

--- a/turbo.json
+++ b/turbo.json
@@ -7,6 +7,7 @@
     },
     "build:watch": {},
     "format": {},
+    "format:check": {},
     "lint": {
       "inputs": ["src/**"],
       "outputs": [],


### PR DESCRIPTION
Use `prettier --check` to verify that the code changes are formatted correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `format:check` script across various packages to validate code formatting using Prettier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->