### PR TITLE
feat: fix release process

### DIFF
--- a/.github/actions/provision/action.yml
+++ b/.github/actions/provision/action.yml
@@ -7,11 +7,13 @@ runs:
       uses: pnpm/action-setup@v4
       with:
         version: '9.1.4'
+
     - name: Set up node
       uses: actions/setup-node@v3
       with:
         node-version: 20
         cache: 'pnpm'
-    - name: install dependencies
+
+    - name: Install dependencies
       run: pnpm install
       shell: bash

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,22 +40,14 @@ jobs:
   deploy:
     needs: release-please
     runs-on: ubuntu-latest
-    # these if statements ensure that a publication only occurs when
-    # a new release is created:
+    # Ensure we only publish if a new release was created
     if: needs.release-please.outputs.releases_created
     steps:
       - uses: actions/checkout@v4
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: '^8.15'
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org/'
-          cache: 'pnpm'
-      - run: pnpm install
+      - uses: ./.github/actions/provision
+
       - run: pnpm build
+
       - run: pnpm -r publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Previous release build failed because pnpm version hadn't been updated in release job. Here, we reuse the provision action with the later version of pnpm.