### PR TITLE
fix: event name is `stx_signMessage`

### DIFF
--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -32,7 +32,6 @@
     "@leather-wallet/prettier-config": "workspace:*",
     "@leather-wallet/tsconfig-config": "workspace:*",
     "@types/react": "18.2.79",
-    "concurrently": "8.2.2",
     "eslint": "8.53.0",
     "prettier": "3.3.0",
     "tsup": "8.1.0",

--- a/packages/rpc/src/methods/stx-sign-message.ts
+++ b/packages/rpc/src/methods/stx-sign-message.ts
@@ -26,7 +26,7 @@ export interface StxSignMessageResponseBody {
   signature: string;
 }
 
-export type StxSignMessageRequest = RpcRequest<'StxSignMessage', StxSignMessageRequestParams>;
+export type StxSignMessageRequest = RpcRequest<'stx_signMessage', StxSignMessageRequestParams>;
 
 export type StxSignMessageResponse = RpcResponse<StxSignMessageResponseBody>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,9 +407,6 @@ importers:
       '@types/react':
         specifier: 18.2.79
         version: 18.2.79
-      concurrently:
-        specifier: 8.2.2
-        version: 8.2.2
       eslint:
         specifier: 8.53.0
         version: 8.53.0


### PR DESCRIPTION
Noticed that this even name is completely wrong 🙃 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the `StxSignMessage` request type to `stx_signMessage` for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->