### PR TITLE
fix: stacks mempool query

### DIFF
--- a/packages/query/src/stacks/stacks-client.ts
+++ b/packages/query/src/stacks/stacks-client.ts
@@ -137,7 +137,7 @@ export function stacksClient(basePath: string) {
       const resp = await rateLimiter.add(
         () =>
           axios.get<MempoolTransactionListResponse>(
-            `${basePath}/extended/v2/addresses/${address}/transactions?limit=${DEFAULT_LIST_LIMIT}`
+            `${basePath}/extended/v1/tx/mempool?address=${address}&limit=${DEFAULT_LIST_LIMIT}`
           ),
         { throwOnTimeout: true }
       );


### PR DESCRIPTION
I had this endpoint wrong so the pending txs weren't working in my extension PR, thx @alter-eggo for catching!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the transactions API endpoint to ensure accurate transaction data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->