### PR TITLE
fix: ecpair import

### DIFF
--- a/packages/bitcoin/src/bip322/bip322-utils.ts
+++ b/packages/bitcoin/src/bip322/bip322-utils.ts
@@ -2,7 +2,7 @@ import ecc from '@bitcoinerlab/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
 import { hexToBytes, utf8ToBytes } from '@stacks/common';
 import * as bitcoin from 'bitcoinjs-lib';
-import ECPairFactory from 'ecpair';
+import { ECPairFactory } from 'ecpair';
 import { encode } from 'varuint-bitcoin';
 
 import { PaymentTypes } from '@leather-wallet/rpc';


### PR DESCRIPTION
I believe this is what broke dev b/w mono repo and extension work. I also removed the `ecpair` lib from the extension here:
https://github.com/leather-wallet/extension/pull/5498

cc @kyranjamie to make sure these changes are ok?

![Screenshot 2024-06-07 at 10 18 16 AM](https://github.com/leather-wallet/mono/assets/6493321/1b892dc4-e3eb-4fba-bcdb-5d21834c11f6)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated import syntax for improved code clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->