### PR TITLE
refactor: relocate stacks raw tx query

### DIFF
--- a/packages/query/src/stacks/mempool/mempool.hooks.ts
+++ b/packages/query/src/stacks/mempool/mempool.hooks.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { MempoolTransaction } from '@stacks/stacks-blockchain-api-types';
 
-import { increaseValueByOneMicroStx, isDefined, microStxToStx } from '@leather-wallet/utils';
+import { increaseValueByOneMicroStx, isUndefined, microStxToStx } from '@leather-wallet/utils';
 
 import { useTransactionsById } from '../transactions/transactions-by-id.query';
 import { useStacksConfirmedTransactions } from '../transactions/transactions-with-transfers.hooks';
@@ -24,7 +24,7 @@ export function useStacksPendingTransactions(address: string) {
       transactions: txs
         .map(tx => tx.data)
         .filter(tx => {
-          if (typeof tx === 'undefined') return false;
+          if (isUndefined(tx)) return false;
           if (droppedCache.has(tx.tx_id)) return false;
           if (tx.tx_status !== 'pending') {
             // Stale txs persist in the mempool endpoint so we
@@ -33,9 +33,7 @@ export function useStacksPendingTransactions(address: string) {
             return false;
           }
           return true;
-        })
-        .filter(tx => !!tx)
-        .filter(isDefined) as MempoolTransaction[],
+        }) as MempoolTransaction[],
     };
   }, [txs, query]);
 }

--- a/packages/query/src/stacks/mempool/mempool.query.ts
+++ b/packages/query/src/stacks/mempool/mempool.query.ts
@@ -12,6 +12,5 @@ export function useAccountMempoolQuery(
     enabled: !!address,
     queryKey: ['account-mempool', address],
     queryFn: () => client.getAddressMempoolTransactions(address),
-    refetchOnWindowFocus: false,
   });
 }

--- a/packages/query/src/stacks/stacks-client.ts
+++ b/packages/query/src/stacks/stacks-client.ts
@@ -143,16 +143,16 @@ export function stacksClient(basePath: string) {
       );
       return resp.data;
     },
-    async getRawTransactionById(txId: string) {
+    async getRawTransactionById(txid: string) {
       const resp = await rateLimiter.add(
-        () => axios.get<GetRawTransactionResult>(`${basePath}/extended/v1/tx/${txId}/raw`),
+        () => axios.get<GetRawTransactionResult>(`${basePath}/extended/v1/tx/${txid}/raw`),
         { throwOnTimeout: true }
       );
       return resp.data;
     },
-    async getTransactionById(txId: string) {
+    async getTransactionById(txid: string) {
       const resp = await rateLimiter.add(
-        () => axios.get<MempoolTransaction | Transaction>(`${basePath}/extended/v1/tx/${txId}`),
+        () => axios.get<MempoolTransaction | Transaction>(`${basePath}/extended/v1/tx/${txid}`),
         { throwOnTimeout: true }
       );
       return resp.data;

--- a/packages/query/src/stacks/transactions/raw-transaction-by-id.query.ts
+++ b/packages/query/src/stacks/transactions/raw-transaction-by-id.query.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useStacksClient } from '../stacks-client';
+
+export function useRawTransactionById(txid: string) {
+  const client = useStacksClient();
+
+  async function rawTransactionByIdFetcher(txid: string) {
+    return client.getRawTransactionById(txid);
+  }
+
+  return useQuery({
+    queryKey: ['raw-transaction-by-id', txid],
+    queryFn: () => rawTransactionByIdFetcher(txid),
+  });
+}

--- a/packages/query/src/stacks/transactions/transactions-by-id.query.ts
+++ b/packages/query/src/stacks/transactions/transactions-by-id.query.ts
@@ -12,8 +12,8 @@ const options = {
 export function useTransactionsById(txids: string[]) {
   const client = useStacksClient();
 
-  async function transactionByIdFetcher(txId: string) {
-    return client.getTransactionById(txId);
+  async function transactionByIdFetcher(txid: string) {
+    return client.getTransactionById(txid);
   }
 
   return useQueries({
@@ -30,8 +30,8 @@ export function useTransactionsById(txids: string[]) {
 export function useTransactionById(txid: string) {
   const client = useStacksClient();
 
-  async function transactionByIdFetcher(txId: string) {
-    return client.getTransactionById(txId);
+  async function transactionByIdFetcher(txid: string) {
+    return client.getTransactionById(txid);
   }
 
   return useQuery({


### PR DESCRIPTION
Came across a random Stacks query in the store I can relocate and remove an old atom keeping track of a raw Stacks txid. Also, I always make the mistake of doing camelCase for `txId`, so fixed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `useRawTransactionById` function to fetch raw transaction data by ID.

- **Refactor**
  - Renamed parameters in transaction-related functions for consistency (`txId` to `txid`).
  - Simplified filtering logic within the `useStacksPendingTransactions` function by renaming `isDefined` to `isUndefined`.

- **Bug Fixes**
  - Removed redundant checks in the `useStacksPendingTransactions` function.
  - Removed `refetchOnWindowFocus` parameter from `useAccountMempoolQuery` to streamline query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->