### PR TITLE
fix: hiro api testnet url path

### DIFF
--- a/packages/models/src/network.model.ts
+++ b/packages/models/src/network.model.ts
@@ -1,7 +1,7 @@
 import { Blockchains } from './types';
 
 export const HIRO_API_BASE_URL_MAINNET = 'https://api.hiro.so';
-export const HIRO_API_BASE_URL_TESTNET = 'https://api.testnet.hiro.so';
+export const HIRO_API_BASE_URL_TESTNET = 'https://api.old.testnet.hiro.so';
 export const HIRO_INSCRIPTIONS_API_URL = 'https://api.hiro.so/ordinals/v1/inscriptions';
 export const HIRO_API_BASE_URL_NAKAMOTO_TESTNET = 'https://api.nakamoto.testnet.hiro.so';
 


### PR DESCRIPTION
@alter-eggo I think this needs to be the `old` path? It seems out of sync with the extension?