### PR TITLE
fix: high fee warning link

### DIFF
--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -2,7 +2,8 @@ export const gaiaUrl = 'https://hub.blockstack.org';
 
 export const HIGH_FEE_AMOUNT_STX = 5;
 export const HIGH_FEE_WARNING_LEARN_MORE_URL_BTC = 'https://bitcoinfees.earn.com/';
-export const HIGH_FEE_WARNING_LEARN_MORE_URL_STX = 'https://hiro.so/questions/fee-estimates';
+export const HIGH_FEE_WARNING_LEARN_MORE_URL_STX =
+  'https://leather.gitbook.io/guides/transactions/fees';
 
 export const DEFAULT_FEE_RATE = 400;
 


### PR DESCRIPTION
fix due to https://github.com/leather-wallet/extension/pull/5350#issuecomment-2112008062

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the URL for the high fee warning "Learn More" link related to STX to ensure users are directed to the correct information page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->