### PR TITLE
fix: disable pointer events on label

### DIFF
--- a/packages/ui/src/components/input/input.web.tsx
+++ b/packages/ui/src/components/input/input.web.tsx
@@ -24,6 +24,7 @@ const transformedLabelStyles: SystemStyleObject = {
   textStyle: 'label.03',
   transform: 'translateY(-12px)',
   fontWeight: 500,
+  pointerEvents: 'all',
 };
 
 const input = sva({
@@ -98,6 +99,9 @@ const input = sva({
       left: 'space.04',
       zIndex: 9,
       color: 'inherit',
+      // In empty state, with no placeholder, click events must be disabled to
+      // allow the label to be ignored, and the underlying input to be focused
+      pointerEvents: 'none',
       textStyle: 'body.02',
       transition: 'font-size 100ms ease-in-out, transform 100ms ease-in-out',
       // Move the input's label to the top when the input has a value


### PR DESCRIPTION
This PR takes a change made in the `extension` in https://github.com/leather-wallet/extension/pull/5537 into the monorepo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved input component styling to enhance user interaction by enabling `pointerEvents`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->