### PR TITLE
fix: test export for png, ref leather-wallet/issues#64

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,11 +6,10 @@
   "scripts": {
     "assets:native": "mkdir -p dist-native/src && cp -r src/assets-native ./dist-native/src/",
     "assets:web": "mkdir -p dist-web/src && cp -r src/assets-web ./dist-web/src",
-    "build": "pnpm panda && pnpm build:native && pnpm build:web && pnpm build:all",
+    "build": "pnpm panda && pnpm build:native && pnpm build:web",
     "build-storybook:web": "storybook build -c ./src/.storybook-web",
-    "build:all": "pnpm assets:web && pnpm assets:native && tsc --build ./tsconfig.json",
     "build:native": "pnpm assets:native && tsc -p ./tsconfig.native.json",
-    "build:watch": "concurrently  \"pnpm panda:watch\"  \"pnpm build:native --watch --preserveWatchOutput\"  \"pnpm build:web --watch --preserveWatchOutput\"  \"pnpm build:all --watch --preserveWatchOutput\" ",
+    "build:watch": "concurrently  \"pnpm panda:watch\"  \"pnpm build:native --watch --preserveWatchOutput\"  \"pnpm build:web --watch --preserveWatchOutput\" ",
     "build:web": "pnpm assets:web && tsup --config tsup.config.web.ts",
     "format": "prettier . --write \"src/**/*.{ts,tsx}\" --ignore-path ../../.prettierignore",
     "format:check": "prettier . --check \"src/**/*.{ts,tsx}\" --ignore-path ../../.prettierignore",
@@ -26,11 +25,11 @@
   },
   "exports": {
     ".": {
-      "types": "./dist-all/web.d.ts",
-      "import": "./dist-all/web.js",
-      "require": "./dist-all/web.js"
+      "types": "./dist-web/web.d.ts",
+      "import": "./dist-web/web.js",
+      "require": "./dist-web/web.js"
     },
-    "./native": "./dist-all/native.js"
+    "./native": "./dist-native/native.js"
   },
   "dependencies": {
     "@expo/vector-icons": "14.0.0",
@@ -102,7 +101,8 @@
     "typescript": "5.3.3"
   },
   "files": [
-    "dist-all"
+    "dist-web",
+    "dist-native"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/ui/src/components/avatar/stx20-avatar-icon.web.tsx
+++ b/packages/ui/src/components/avatar/stx20-avatar-icon.web.tsx
@@ -1,4 +1,5 @@
-import Stx20AvatarIconSrc from '../../assets-web/avatars/stx20-avatar-icon.png';
+import Stx20AvatarIconSrc from 'src/assets-web/avatars/stx20-avatar-icon.png';
+
 import { Avatar, type AvatarProps } from './avatar.web';
 
 const fallback = 'ST';


### PR DESCRIPTION
This PR changes the entry point for the UI package to load from `dist-web` / `dist-native` instead of `dist-all`. 

I need to do some more work investigating the best way of doing this however I want to change this now so I can finish migrating more components. 

If I don't do this, I get an installation error in the `extension` as it cannot find the `.png` source files for `Stx20AvatarIcon` and `StampsAvatarIcon`   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated internal paths for type definitions, imports, and dependencies to improve module organization.
	- Changed import statements to use absolute paths for better consistency in the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->